### PR TITLE
feat: add poll store, and object logic in poll creation interactions

### DIFF
--- a/src/handlers/button-handler.ts
+++ b/src/handlers/button-handler.ts
@@ -6,6 +6,7 @@ import { cancelEditQuestion } from "./buttons/cancel-edit-question";
 import { removeQuestion } from "./buttons/remove-question";
 import { confirmRemoveQuestions } from "./buttons/confirm-remove-questions";
 import { cancelRemoveQuestions } from "./buttons/cancel-remove-questions";
+import { editPollTitle } from "./buttons/edit-poll-title";
 
 export async function handleButton(interaction: ButtonInteraction) {
 	if (interaction.customId === "feedbackCreateButton") {
@@ -58,5 +59,7 @@ export async function handleButton(interaction: ButtonInteraction) {
 			content: "Modification annulée", 
 			flags: MessageFlags.Ephemeral 
 		});
+	} else if(interaction.customId === "feedbackEditTitleButton"){
+		await editPollTitle(interaction);
 	}
 }

--- a/src/handlers/button-handler.ts
+++ b/src/handlers/button-handler.ts
@@ -7,6 +7,7 @@ import { removeQuestion } from "./buttons/remove-question";
 import { confirmRemoveQuestions } from "./buttons/confirm-remove-questions";
 import { cancelRemoveQuestions } from "./buttons/cancel-remove-questions";
 import { editPollTitle } from "./buttons/edit-poll-title";
+import { editPollAnonymous } from "./buttons/edit-poll-anonymous";
 
 export async function handleButton(interaction: ButtonInteraction) {
 	if (interaction.customId === "feedbackCreateButton") {
@@ -25,41 +26,43 @@ export async function handleButton(interaction: ButtonInteraction) {
 		await cancelRemoveQuestions(interaction);
 	} else if (interaction.customId.startsWith("editQuestionText_")) {
 		// Gérer la modification du texte de la question (sera implémenté plus tard)
-		await interaction.reply({ 
-			content: "Fonctionnalité de modification du texte en cours d'implémentation", 
-			flags: MessageFlags.Ephemeral 
+		await interaction.reply({
+			content: "Fonctionnalité de modification du texte en cours d'implémentation",
+			flags: MessageFlags.Ephemeral
 		});
 	} else if (interaction.customId.startsWith("addProposal_")) {
 		// Gérer l'ajout d'une proposition (sera implémenté plus tard)
-		await interaction.reply({ 
-			content: "Fonctionnalité d'ajout de proposition en cours d'implémentation", 
-			flags: MessageFlags.Ephemeral 
+		await interaction.reply({
+			content: "Fonctionnalité d'ajout de proposition en cours d'implémentation",
+			flags: MessageFlags.Ephemeral
 		});
 	} else if (interaction.customId.startsWith("editProposal_")) {
 		// Gérer la modification d'une proposition (sera implémenté plus tard)
-		await interaction.reply({ 
-			content: "Fonctionnalité de modification de proposition en cours d'implémentation", 
-			flags: MessageFlags.Ephemeral 
+		await interaction.reply({
+			content: "Fonctionnalité de modification de proposition en cours d'implémentation",
+			flags: MessageFlags.Ephemeral
 		});
 	} else if (interaction.customId.startsWith("deleteProposal_")) {
 		// Gérer la suppression d'une proposition (sera implémenté plus tard)
-		await interaction.reply({ 
-			content: "Fonctionnalité de suppression de proposition en cours d'implémentation", 
-			flags: MessageFlags.Ephemeral 
+		await interaction.reply({
+			content: "Fonctionnalité de suppression de proposition en cours d'implémentation",
+			flags: MessageFlags.Ephemeral
 		});
 	} else if (interaction.customId.startsWith("saveQuestion_")) {
 		// Gérer l'enregistrement de la question (sera implémenté plus tard)
-		await interaction.reply({ 
-			content: "Fonctionnalité d'enregistrement en cours d'implémentation", 
-			flags: MessageFlags.Ephemeral 
+		await interaction.reply({
+			content: "Fonctionnalité d'enregistrement en cours d'implémentation",
+			flags: MessageFlags.Ephemeral
 		});
 	} else if (interaction.customId.startsWith("cancelEdit_")) {
 		// Gérer l'annulation de la modification (sera implémenté plus tard)
-		await interaction.reply({ 
-			content: "Modification annulée", 
-			flags: MessageFlags.Ephemeral 
+		await interaction.reply({
+			content: "Modification annulée",
+			flags: MessageFlags.Ephemeral
 		});
-	} else if(interaction.customId === "feedbackEditTitleButton"){
+	} else if (interaction.customId === "feedbackEditTitleButton") {
 		await editPollTitle(interaction);
+	} else if (interaction.customId === "feedbackAnonymousButton") {
+		await editPollAnonymous(interaction);
 	}
 }

--- a/src/handlers/buttons/add-question.ts
+++ b/src/handlers/buttons/add-question.ts
@@ -1,18 +1,7 @@
 import { ActionRowBuilder, ButtonInteraction, ModalBuilder, TextInputBuilder, TextInputStyle, MessageFlags } from "discord.js";
 
 export async function addQuestion(interaction: ButtonInteraction) {
-    try {
-        // Récupérer le message original
-        const message = interaction.message;
-        
-        if (!message) {
-            await interaction.reply({ 
-                content: "Erreur: Message introuvable", 
-                flags: MessageFlags.Ephemeral 
-            });
-            return;
-        }
-        
+    try {        
         // Créer un champ de texte pour la question
         const questionInput = new TextInputBuilder()
             .setCustomId("questionContent")

--- a/src/handlers/buttons/cancel-edit-question.ts
+++ b/src/handlers/buttons/cancel-edit-question.ts
@@ -1,6 +1,6 @@
 import { ButtonInteraction, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollEmbed, pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRows } from "../../utils/components";
 import { getPollObject } from "../../utils/poll-store";
 
 export async function cancelEditQuestion(interaction: ButtonInteraction) {
@@ -21,7 +21,7 @@ export async function cancelEditQuestion(interaction: ButtonInteraction) {
 		await interaction.update({
 			content: null,
 			embeds: [pollEmbed(poll)],
-			components: [pollRow1()]
+			components: pollRows()
 		});
 
 	} catch (error) {

--- a/src/handlers/buttons/cancel-edit-question.ts
+++ b/src/handlers/buttons/cancel-edit-question.ts
@@ -1,35 +1,26 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedBuilder, MessageFlags } from "discord.js";
+import { ButtonInteraction, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRow1 } from "../../utils/components";
+import { getPollObject } from "../../utils/poll-store";
 
 export async function cancelEditQuestion(interaction: ButtonInteraction) {
 	try {
-		// Récupérer le message original
-		const message = interaction.message;
-		if (!message) {
+
+		const poll = getPollObject(interaction.user.id);
+		if (!poll) {
 			await interaction.reply({
-				content: "Erreur: Message introuvable",
+				content: "Impossible de trouver le sondage. Veuillez réessayer.",
 				flags: MessageFlags.Ephemeral
 			});
+			setTimeout(async () => {
+				await interaction.deleteReply();
+			}, logMessageTimer);
 			return;
 		}
-
-		// Récupérer l'embed existant
-		const embed = EmbedBuilder.from(message.embeds[0]);
-
-		// S'assurer que le footer est présent
-		if (!embed.data.footer) {
-			embed.setFooter({
-				text: "Utilisez les boutons ci-dessous pour gérer les questions du sondage"
-			});
-		}
-
-		
-
 		// Mettre à jour le message avec un message de confirmation temporaire
 		await interaction.update({
 			content: null,
-			embeds: [embed],
+			embeds: [pollEmbed(poll)],
 			components: [pollRow1()]
 		});
 

--- a/src/handlers/buttons/cancel-remove-questions.ts
+++ b/src/handlers/buttons/cancel-remove-questions.ts
@@ -1,34 +1,28 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedBuilder, MessageFlags } from "discord.js";
+import { ButtonInteraction, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollRow1 } from "../../utils/components";
-
-// Déclarer le type pour les variables globales
-declare global {
-	var selectedQuestionsToRemove: string[] | undefined;
-}
+import { pollEmbed, pollRow1 } from "../../utils/components";
+import { getPollObject } from "../../utils/poll-store";
 
 export async function cancelRemoveQuestions(interaction: ButtonInteraction) {
 	try {
-		// Récupérer le message original
-		const message = interaction.message;
-		if (!message) {
+		const poll = getPollObject(interaction.user.id);
+		if (!poll) {
 			await interaction.reply({
-				content: "Erreur: Message introuvable",
+				content: "Impossible de trouver le sondage. Veuillez réessayer.",
 				flags: MessageFlags.Ephemeral
 			});
+			setTimeout(async () => {
+				await interaction.deleteReply();
+			}, logMessageTimer);
 			return;
 		}
-
-		// Récupérer l'embed existant
-		const embed = EmbedBuilder.from(message.embeds[0]);
-
 		// Réinitialiser les variables globales
-		global.selectedQuestionsToRemove = undefined;
+		poll.selectedQuestions.length = 0;
 
 		// Mettre à jour le message pour restaurer l'interface principale
 		await interaction.update({
 			content: null,
-			embeds: [embed],
+			embeds: [pollEmbed(poll)],
 			components: [pollRow1()]
 		});
 

--- a/src/handlers/buttons/cancel-remove-questions.ts
+++ b/src/handlers/buttons/cancel-remove-questions.ts
@@ -1,6 +1,6 @@
 import { ButtonInteraction, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollEmbed, pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRows } from "../../utils/components";
 import { getPollObject } from "../../utils/poll-store";
 
 export async function cancelRemoveQuestions(interaction: ButtonInteraction) {
@@ -23,7 +23,7 @@ export async function cancelRemoveQuestions(interaction: ButtonInteraction) {
 		await interaction.update({
 			content: null,
 			embeds: [pollEmbed(poll)],
-			components: [pollRow1()]
+			components: pollRows()
 		});
 
 	} catch (error) {

--- a/src/handlers/buttons/confirm-remove-questions.ts
+++ b/src/handlers/buttons/confirm-remove-questions.ts
@@ -1,16 +1,24 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedBuilder, MessageFlags } from "discord.js";
+import { ButtonInteraction, EmbedBuilder, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollRow1 } from "../../utils/components";
-
-// Variable globale pour stocker les questions sélectionnées pour la suppression
-declare global {
-	var selectedQuestionsToRemove: string[] | undefined;
-}
+import { pollEmbed, pollRow1 } from "../../utils/components";
+import { getPollObject, removePollQuestion } from "../../utils/poll-store";
 
 export async function confirmRemoveQuestions(interaction: ButtonInteraction) {
 	try {
+		const poll = getPollObject(interaction.user.id);
+		if (!poll) {
+			await interaction.reply({
+				content: "Impossible de trouver le sondage. Veuillez réessayer.",
+				flags: MessageFlags.Ephemeral
+			});
+			setTimeout(async () => {
+				await interaction.deleteReply();
+			}, logMessageTimer);
+			return;
+		}
+		const questions = poll.questions;
 		// Vérifier si des questions ont été sélectionnées
-		if (!global.selectedQuestionsToRemove || global.selectedQuestionsToRemove.length === 0) {
+		if (poll.selectedQuestions.length === 0) {
 			await interaction.reply({
 				content: "Aucune question n'a été sélectionnée pour la suppression. Veuillez d'abord sélectionner des questions.",
 				flags: MessageFlags.Ephemeral
@@ -23,72 +31,18 @@ export async function confirmRemoveQuestions(interaction: ButtonInteraction) {
 			return;
 		}
 
-		// Récupérer l'embed existant
-		const message = interaction.message;
-		if (!message) {
-			await interaction.reply({
-				content: "Erreur: Message introuvable",
-				flags: MessageFlags.Ephemeral
-			});
-			return;
-		}
-
-		const embed = EmbedBuilder.from(message.embeds[0]);
-		const description = embed.data.description || "";
-
-		// Extraire les sections du message
-		const sections = description.split("\n\n");
-
-		// Identifier les questions et les autres sections
-		const questionSections = sections.filter(q => q.includes("**Question"));
-		const nonQuestionSections = sections.filter(q => !q.includes("**Question"));
-
-		// Convertir les indices de questions sélectionnées en nombres
-		const selectedIndices = global.selectedQuestionsToRemove.map(id =>
-			parseInt(id.replace("question_", ""))
-		);
-
-		console.log(`Indices des questions à supprimer: ${selectedIndices.join(", ")}`);
-
-		// Filtrer les questions pour ne garder que celles qui ne sont pas sélectionnées pour la suppression
-		const remainingQuestions = questionSections.filter((_, index) =>
-			!selectedIndices.includes(index)
-		);
-
-		// Renuméroter les questions restantes
-		const renumberedQuestions = remainingQuestions.map((question, index) => {
-			return question.replace(/\*\*Question \d+\*\*/, `**Question ${index + 1}**`);
-		});
-
-		// Reconstruire la description avec les sections non-questions et les questions restantes
-		let newDescription = "";
-
-		// Ajouter les sections non-questions au début
-		if (nonQuestionSections.length > 0) {
-			newDescription = nonQuestionSections.join("\n\n") + "\n\n";
-		}
-
-		// Ajouter les questions restantes
-		if (renumberedQuestions.length > 0) {
-			newDescription += renumberedQuestions.join("\n\n");
-		} else {
-			// S'il n'y a plus de questions, ajouter un message
-			newDescription += "Aucune question n'a encore été ajoutée à ce sondage.";
-		}
-
-		// Mettre à jour l'embed avec la nouvelle description
-		embed.setDescription(newDescription);
-
-		// Réinitialiser les variables globales
-		global.selectedQuestionsToRemove = undefined;
+		console.log(`Indices des questions à supprimer: ${poll.selectedQuestions.join(", ")}`);
 
 		// Créer un message temporaire pour confirmer la suppression
-		const confirmationMessage = `${selectedIndices.length} question(s) supprimée(s) avec succès.`;
+		const confirmationMessage = `${poll.selectedQuestions.length} question(s) supprimée(s) avec succès.`;
+
+		// Supprimer les questions sélectionnées
+		removePollQuestion(poll);
 
 		// Mettre à jour le message original
 		await interaction.update({
 			content: null,
-			embeds: [embed],
+			embeds: [pollEmbed(poll)],
 			components: [pollRow1()]
 		});
 

--- a/src/handlers/buttons/confirm-remove-questions.ts
+++ b/src/handlers/buttons/confirm-remove-questions.ts
@@ -1,6 +1,6 @@
 import { ButtonInteraction, EmbedBuilder, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollEmbed, pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRows } from "../../utils/components";
 import { getPollObject, removePollQuestion } from "../../utils/poll-store";
 
 export async function confirmRemoveQuestions(interaction: ButtonInteraction) {
@@ -16,7 +16,7 @@ export async function confirmRemoveQuestions(interaction: ButtonInteraction) {
 			}, logMessageTimer);
 			return;
 		}
-		const questions = poll.questions;
+		
 		// Vérifier si des questions ont été sélectionnées
 		if (poll.selectedQuestions.length === 0) {
 			await interaction.reply({
@@ -43,7 +43,7 @@ export async function confirmRemoveQuestions(interaction: ButtonInteraction) {
 		await interaction.update({
 			content: null,
 			embeds: [pollEmbed(poll)],
-			components: [pollRow1()]
+			components: pollRows()
 		});
 
 		const followUp = await interaction.followUp({

--- a/src/handlers/buttons/create-poll.ts
+++ b/src/handlers/buttons/create-poll.ts
@@ -2,7 +2,7 @@ import { ActionRowBuilder, ButtonInteraction, ModalBuilder, TextInputBuilder, Te
 
 export async function createPoll(interaction: ButtonInteraction) {
     const titleInput = new TextInputBuilder()
-        .setLabel("Titre du sondage")
+        .setLabel("Titre du questionnaire")
         .setCustomId("pollTitle")
         .setStyle(TextInputStyle.Short)
         .setMaxLength(50);
@@ -11,8 +11,8 @@ export async function createPoll(interaction: ButtonInteraction) {
         .addComponents(titleInput);
 
     const modal = new ModalBuilder()
-        .setCustomId("pollTitleModal")
-        .setTitle('Titre du questionnaire')
+        .setCustomId("createPollTitleModal")
+        .setTitle('Créer un questionnaire')
         .addComponents(modalRow);
 
     await interaction.showModal(modal);

--- a/src/handlers/buttons/edit-poll-anonymous.ts
+++ b/src/handlers/buttons/edit-poll-anonymous.ts
@@ -1,0 +1,28 @@
+import { ButtonInteraction, MessageFlags } from "discord.js";
+import { pollEmbed, initRow, pollRows } from "../../utils/components";
+import { getPollObject } from "../../utils/poll-store";
+import { logMessageTimer } from "../../utils/timer";
+
+export async function editPollAnonymous(interaction: ButtonInteraction) {
+    // Récupérer le sondage en cours d'édition
+    const poll = getPollObject(interaction.user.id);
+    if (!poll) {
+        await interaction.reply({
+            content: "Impossible de trouver le sondage. Veuillez réessayer.",
+            flags: MessageFlags.Ephemeral
+        });
+        setTimeout(async () => {
+            await interaction.deleteReply();
+        }, logMessageTimer);
+        return;
+    }
+
+    // Inverser le statut d'anonymat du sondage
+    poll.isAnonymous = !poll.isAnonymous;
+
+    // Mettre à jour le message
+    await interaction.update({
+        embeds: [pollEmbed(poll)],
+        components: pollRows()
+    });
+}

--- a/src/handlers/buttons/edit-poll-title.ts
+++ b/src/handlers/buttons/edit-poll-title.ts
@@ -1,0 +1,35 @@
+import { ActionRowBuilder, ButtonInteraction, MessageFlags, ModalBuilder, TextInputBuilder, TextInputStyle } from "discord.js";
+import { getPollObject } from "../../utils/poll-store";
+import { logMessageTimer } from "../../utils/timer";
+
+export async function editPollTitle(interaction: ButtonInteraction) {
+
+    const poll = getPollObject(interaction.user.id);
+    if (!poll) {
+        await interaction.reply({
+            content: "Impossible de trouver le sondage. Veuillez réessayer.",
+            flags: MessageFlags.Ephemeral
+        });
+        setTimeout(async () => {
+            await interaction.deleteReply();
+        }, logMessageTimer);
+        return;
+    }
+
+    const titleInput = new TextInputBuilder()
+        .setLabel("Nouveau titre du questionnaire")
+        .setCustomId("pollTitle")
+        .setStyle(TextInputStyle.Short)
+        .setMaxLength(50)
+        .setValue(poll.title);
+
+    const modalRow = new ActionRowBuilder<TextInputBuilder>()
+        .addComponents(titleInput);
+
+    const modal = new ModalBuilder()
+        .setCustomId("editPollTitleModal")
+        .setTitle('Modifier le questionnaire')
+        .addComponents(modalRow);
+
+    await interaction.showModal(modal);
+}

--- a/src/handlers/buttons/edit-question.ts
+++ b/src/handlers/buttons/edit-question.ts
@@ -1,34 +1,31 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
+import { getPollObject } from "../../utils/poll-store";
+import { pollEmbed } from "../../utils/components";
 
 export async function editQuestion(interaction: ButtonInteraction) {
     try {
-        // Récupérer le message original
-        const message = interaction.message;
-        if (!message) {
-            await interaction.reply({ 
-                content: "Erreur: Message introuvable", 
-                flags: MessageFlags.Ephemeral 
+        const poll = getPollObject(interaction.user.id);
+        if (!poll) {
+            await interaction.reply({
+                content: "Impossible de trouver le sondage. Veuillez réessayer.",
+                flags: MessageFlags.Ephemeral
             });
+            setTimeout(async () => {
+                await interaction.deleteReply();
+            }, logMessageTimer);
             return;
         }
-        
-        // Récupérer l'embed existant
-        const embed = EmbedBuilder.from(message.embeds[0]);
-        const description = embed.data.description || "";
-        
-        // Extraire les questions du message
-        // Diviser par "\n\n" et filtrer pour trouver les lignes qui contiennent "**Question"
-        const sections = description.split("\n\n");
-        const questions = sections.filter(q => q.includes("**Question"));
-        
+
+        const questions = poll.questions;
+
         console.log(`Questions trouvées: ${questions.length}`);
-        
+
         // Si aucune question n'est trouvée
         if (questions.length === 0) {
-            await interaction.reply({ 
-                content: "Aucune question à modifier. Veuillez d'abord ajouter une question au sondage.", 
-                flags: MessageFlags.Ephemeral 
+            await interaction.reply({
+                content: "Aucune question à modifier. Veuillez d'abord ajouter une question au sondage.",
+                flags: MessageFlags.Ephemeral
             });
 
             setTimeout(async () => {
@@ -36,53 +33,46 @@ export async function editQuestion(interaction: ButtonInteraction) {
             }, logMessageTimer);
             return;
         }
-        
+
         // Créer un menu déroulant pour sélectionner la question à modifier
         const selectMenu = new StringSelectMenuBuilder()
             .setCustomId("questionSelectMenu")
             .setPlaceholder("Sélectionnez une question à modifier");
-        
+
         // Ajouter chaque question comme option
         questions.forEach((question, index) => {
-            // Extraire le texte de la question (sans le préfixe "**Question X:**")
-            const questionText = question.replace(/\*\*Question \d+:\*\*/, "").trim();
-            // Limiter le texte à 100 caractères pour l'affichage
-            const displayText = questionText.length > 95 
-                ? questionText.substring(0, 95) + "..." 
-                : questionText;
-            
             selectMenu.addOptions(
                 new StringSelectMenuOptionBuilder()
                     .setLabel(`Question ${index + 1}`)
-                    .setDescription(displayText)
+                    .setDescription(question.content)
                     .setValue(`question_${index}`)
             );
         });
-        
+
         // Créer le bouton d'annulation
         const cancelButton = new ButtonBuilder()
             .setCustomId("cancelEditQuestion")
             .setLabel("Annuler")
             .setStyle(ButtonStyle.Secondary);
-        
+
         // Créer les lignes pour les composants
         const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>()
             .addComponents(selectMenu);
-        
+
         const buttonRow = new ActionRowBuilder<ButtonBuilder>()
             .addComponents(cancelButton);
-        
+
         // Mettre à jour le message avec le menu de sélection
         await interaction.update({
             content: "Sélectionnez la question que vous souhaitez modifier :",
-            embeds: [embed],
+            embeds: [pollEmbed(poll)],
             components: [selectRow, buttonRow]
         });
     } catch (error) {
         console.error("Erreur lors de l'édition de question:", error);
-        await interaction.reply({ 
-            content: "Une erreur est survenue lors de la modification de la question. Veuillez réessayer.", 
-            flags: MessageFlags.Ephemeral 
+        await interaction.reply({
+            content: "Une erreur est survenue lors de la modification de la question. Veuillez réessayer.",
+            flags: MessageFlags.Ephemeral
         });
     }
 } 

--- a/src/handlers/buttons/remove-question.ts
+++ b/src/handlers/buttons/remove-question.ts
@@ -1,53 +1,51 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
+import { getPollObject } from "../../utils/poll-store";
+import { pollEmbed } from "../../utils/components";
 
 export async function removeQuestion(interaction: ButtonInteraction) {
     try {
-        // Récupérer le message original
-        const message = interaction.message;
-        if (!message) {
-            await interaction.reply({ 
-                content: "Erreur: Message introuvable", 
-                flags: MessageFlags.Ephemeral 
-            });
-            return;
-        }
-        
-        // Récupérer l'embed existant
-        const embed = EmbedBuilder.from(message.embeds[0]);
-        const description = embed.data.description || "";
-        
-        // Extraire les questions du message
-        const sections = description.split("\n\n");
-        const questions = sections.filter(q => q.includes("**Question"));
-        
-        console.log(`Questions trouvées pour la suppression: ${questions.length}`);
-        
-        // Vérifier s'il y a des questions à supprimer
-        if (questions.length === 0) {
-            await interaction.reply({ 
-                content: "Aucune question à supprimer. Ajoutez d'abord des questions au sondage.", 
-                flags: MessageFlags.Ephemeral 
+        const poll = getPollObject(interaction.user.id);
+        if (!poll) {
+            await interaction.reply({
+                content: "Impossible de trouver le sondage. Veuillez réessayer.",
+                flags: MessageFlags.Ephemeral
             });
             setTimeout(async () => {
                 await interaction.deleteReply();
             }, logMessageTimer);
             return;
         }
-        
+
+        const questions = poll.questions;
+
+        console.log(`Questions trouvées pour la suppression: ${questions.length}`);
+
+        // Vérifier s'il y a des questions à supprimer
+        if (questions.length === 0) {
+            await interaction.reply({
+                content: "Aucune question à supprimer. Ajoutez d'abord des questions au sondage.",
+                flags: MessageFlags.Ephemeral
+            });
+            setTimeout(async () => {
+                await interaction.deleteReply();
+            }, logMessageTimer);
+            return;
+        }
+
         // Créer les options du menu de sélection pour chaque question
         const options = questions.map((question, index) => {
             // Extraire le texte de la question (sans le numéro et le préfixe)
-            const questionText = question.replace(/\*\*Question \d+\*\*: /, "").trim();
+            const questionText = question.content;
             // Limiter la longueur du texte pour l'option
-            const shortText = questionText.length > 90 ? questionText.substring(0, 87) + "..." : questionText;
-            
+            const shortText = questionText.length > 100 ? questionText.substring(0, 97) + "..." : questionText;
+
             return new StringSelectMenuOptionBuilder()
                 .setLabel(`Question ${index + 1}`)
                 .setDescription(shortText)
                 .setValue(`question_${index}`);
         });
-        
+
         // Créer le menu de sélection
         const selectMenu = new StringSelectMenuBuilder()
             .setCustomId("questionRemoveMenu")
@@ -55,36 +53,36 @@ export async function removeQuestion(interaction: ButtonInteraction) {
             .setMinValues(1)
             .setMaxValues(questions.length)
             .addOptions(options);
-        
+
         // Créer les boutons de confirmation et d'annulation
         const confirmButton = new ButtonBuilder()
             .setCustomId("confirmRemoveQuestions")
             .setLabel("Confirmer la suppression")
             .setStyle(ButtonStyle.Danger);
-        
+
         const cancelButton = new ButtonBuilder()
             .setCustomId("cancelRemoveQuestions")
             .setLabel("Annuler")
             .setStyle(ButtonStyle.Secondary);
-        
+
         // Créer les lignes pour les composants
         const actionRow1 = new ActionRowBuilder<StringSelectMenuBuilder>()
             .addComponents(selectMenu);
-        
+
         const actionRow2 = new ActionRowBuilder<ButtonBuilder>()
             .addComponents(confirmButton, cancelButton);
-        
+
         // Mettre à jour le message avec les options de suppression
         await interaction.update({
             content: "Sélectionnez les questions à supprimer, puis cliquez sur 'Confirmer la suppression'",
-            embeds: [embed],
+            embeds: [pollEmbed(poll)],
             components: [actionRow1, actionRow2]
         });
     } catch (error) {
         console.error("Erreur lors de la préparation de la suppression de questions:", error);
-        await interaction.reply({ 
-            content: "Une erreur est survenue lors de la préparation de la suppression de questions. Veuillez réessayer.", 
-            flags: MessageFlags.Ephemeral 
+        await interaction.reply({
+            content: "Une erreur est survenue lors de la préparation de la suppression de questions. Veuillez réessayer.",
+            flags: MessageFlags.Ephemeral
         });
     }
 } 

--- a/src/handlers/modal-handler.ts
+++ b/src/handlers/modal-handler.ts
@@ -1,16 +1,19 @@
 import { ModalSubmitInteraction } from "discord.js";
 import { createPoll } from "./modals/create-poll";
 import { addQuestion } from "./modals/add-question";
+import { editPollTitle } from "./modals/edit-poll-title";
 
 export async function handleModal(interaction: ModalSubmitInteraction) {
     console.log(`Modal soumis avec customId: ${interaction.customId}`);
     
-    if (interaction.customId === "pollTitleModal") {
+    if (interaction.customId === "createPollTitleModal") {
         console.log("Traitement du modal de création de sondage");
         await createPoll(interaction);
     } else if (interaction.customId === "addQuestionModal") {
         console.log("Traitement du modal d'ajout de question");
         await addQuestion(interaction);
+    } else if (interaction.customId === "editPollTitleModal"){
+        await editPollTitle(interaction);
     } else {
         console.log(`Modal non reconnu: ${interaction.customId}`);
     }

--- a/src/handlers/modals/add-question.ts
+++ b/src/handlers/modals/add-question.ts
@@ -1,49 +1,31 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, ModalSubmitInteraction, MessageFlags } from "discord.js";
+import { ModalSubmitInteraction, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRow1 } from "../../utils/components";
+import { addPollQuestion, getPollObject } from "../../utils/poll-store";
 
 export async function addQuestion(interaction: ModalSubmitInteraction) {
 	try {
 		// Récupérer le contenu de la question depuis le modal
 		const questionContent = interaction.fields.getTextInputValue("questionContent");
 
-		// Récupérer le message original
-		let message = interaction.message;
-		if (!message) {
+		const poll = getPollObject(interaction.user.id);
+		if (poll) {
+			addPollQuestion(poll, questionContent);
+		} else {
 			await interaction.reply({
-				content: "Erreur: Message introuvable. Recommencez le questionnaire depuis le début.",
+				content: "Impossible de trouver le sondage. Veuillez réessayer.",
 				flags: MessageFlags.Ephemeral
 			});
+			setTimeout(async () => {
+				await interaction.deleteReply();
+			}, logMessageTimer);
 			return;
-		}
-		// Récupérer l'embed existant et mettre à jour la description
-		const embed = EmbedBuilder.from(message.embeds[0]);
-		const currentDescription = embed.data.description || "Aucune question";
-
-		// Ajouter la nouvelle question à la description
-		let updatedDescription;
-		if (currentDescription === "Les questions" || currentDescription === "Aucune question" || currentDescription === "Aucune question n'a encore été ajoutée à ce sondage.") {
-			updatedDescription = `**Question 1:** ${questionContent}`;
-		} else {
-			// Compter le nombre de questions existantes
-			const questionMatches = currentDescription.match(/\*\*Question \d+:\*\*/g);
-			const questionCount = questionMatches ? questionMatches.length : 0;
-			updatedDescription = `${currentDescription}\n\n**Question ${questionCount + 1}:** ${questionContent}`;
-		}
-
-		embed.setDescription(updatedDescription);
-
-		// S'assurer que le footer est présent
-		if (!embed.data.footer) {
-			embed.setFooter({
-				text: "Utilisez les boutons ci-dessous pour gérer les questions du sondage"
-			});
 		}
 
 		// Mettre à jour le message existant
 		await interaction.deferUpdate();
 		await interaction.editReply({
-			embeds: [embed],
+			embeds: [pollEmbed(poll)],
 			components: [pollRow1()],
 		});
 

--- a/src/handlers/modals/add-question.ts
+++ b/src/handlers/modals/add-question.ts
@@ -1,6 +1,6 @@
 import { ModalSubmitInteraction, MessageFlags } from "discord.js";
 import { logMessageTimer } from "../../utils/timer";
-import { pollEmbed, pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRows } from "../../utils/components";
 import { addPollQuestion, getPollObject } from "../../utils/poll-store";
 
 export async function addQuestion(interaction: ModalSubmitInteraction) {
@@ -26,7 +26,7 @@ export async function addQuestion(interaction: ModalSubmitInteraction) {
 		await interaction.deferUpdate();
 		await interaction.editReply({
 			embeds: [pollEmbed(poll)],
-			components: [pollRow1()],
+			components: pollRows(),
 		});
 
 		const followUp = await interaction.followUp({

--- a/src/handlers/modals/create-poll.ts
+++ b/src/handlers/modals/create-poll.ts
@@ -1,5 +1,5 @@
 import { MessageFlags, ModalSubmitInteraction } from "discord.js";
-import { pollEmbed, pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRows, pollRow2 } from "../../utils/components";
 import { createPollObject } from "../../utils/poll-store";
 
 export async function createPoll(interaction: ModalSubmitInteraction) {
@@ -9,7 +9,7 @@ export async function createPoll(interaction: ModalSubmitInteraction) {
 	// Envoyer le sondage comme un message éphémère dans le canal
 	await interaction.reply({
 		embeds: [pollEmbed(poll)],
-		components: [pollRow1()],
+		components: pollRows(),
 		flags: MessageFlags.Ephemeral
 	});
 }

--- a/src/handlers/modals/create-poll.ts
+++ b/src/handlers/modals/create-poll.ts
@@ -1,19 +1,14 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags, ModalSubmitInteraction } from "discord.js";
-import { pollRow1 } from "../../utils/components";
+import { MessageFlags, ModalSubmitInteraction } from "discord.js";
+import { pollEmbed, pollRow1 } from "../../utils/components";
+import { createPollObject } from "../../utils/poll-store";
 
 export async function createPoll(interaction: ModalSubmitInteraction) {
-	const embed = new EmbedBuilder()
-		.setTitle(`Titre : ${interaction.fields.getTextInputValue('pollTitle')}`)
-		.setDescription(
-			"Aucune question n'a encore été ajoutée à ce sondage."
-		)
-		.setFooter({
-			text: "Utilisez les boutons ci-dessous pour gérer les questions du sondage"
-		});
+
+	const poll = createPollObject(interaction.user.id, interaction.fields.getTextInputValue('pollTitle'));
 
 	// Envoyer le sondage comme un message éphémère dans le canal
 	await interaction.reply({
-		embeds: [embed],
+		embeds: [pollEmbed(poll)],
 		components: [pollRow1()],
 		flags: MessageFlags.Ephemeral
 	});

--- a/src/handlers/modals/edit-poll-title.ts
+++ b/src/handlers/modals/edit-poll-title.ts
@@ -1,0 +1,25 @@
+import { MessageFlags, ModalSubmitInteraction } from "discord.js";
+import { getPollObject } from "../../utils/poll-store";
+import { logMessageTimer } from "../../utils/timer";
+import { pollEmbed, pollRow1 } from "../../utils/components";
+
+export async function editPollTitle(interaction: ModalSubmitInteraction) {
+    const poll = getPollObject(interaction.user.id);
+    if (!poll) {
+        await interaction.reply({
+            content: "Impossible de trouver le sondage. Veuillez réessayer.",
+            flags: MessageFlags.Ephemeral
+        });
+        setTimeout(async () => {
+            await interaction.deleteReply();
+        }, logMessageTimer);
+        return;
+    }
+
+    poll.title = interaction.fields.getTextInputValue("pollTitle");
+    await interaction.deferUpdate();
+    await interaction.editReply({
+        embeds: [pollEmbed(poll)],
+        components: [pollRow1()],
+    });
+}

--- a/src/handlers/modals/edit-poll-title.ts
+++ b/src/handlers/modals/edit-poll-title.ts
@@ -1,7 +1,7 @@
 import { MessageFlags, ModalSubmitInteraction } from "discord.js";
 import { getPollObject } from "../../utils/poll-store";
 import { logMessageTimer } from "../../utils/timer";
-import { pollEmbed, pollRow1 } from "../../utils/components";
+import { pollEmbed, pollRows } from "../../utils/components";
 
 export async function editPollTitle(interaction: ModalSubmitInteraction) {
     const poll = getPollObject(interaction.user.id);
@@ -20,6 +20,6 @@ export async function editPollTitle(interaction: ModalSubmitInteraction) {
     await interaction.deferUpdate();
     await interaction.editReply({
         embeds: [pollEmbed(poll)],
-        components: [pollRow1()],
+        components: pollRows(),
     });
 }

--- a/src/handlers/select-menu-handler.ts
+++ b/src/handlers/select-menu-handler.ts
@@ -7,7 +7,7 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
         await questionSelect(interaction);
     } else if (interaction.customId === "questionRemoveMenu") {
         await questionRemove(interaction);
-    } else if (interaction.customId.startsWith("multipleChoice_")) {
+    } else if (interaction.customId === "questionMultipleChoiceMenu") {
         await interaction.deferUpdate();
     }
 } 

--- a/src/handlers/select-menus/question-remove.ts
+++ b/src/handlers/select-menus/question-remove.ts
@@ -1,29 +1,35 @@
 import { StringSelectMenuInteraction, MessageFlags } from "discord.js";
-
-// Variable globale pour stocker les questions sélectionnées pour la suppression
-declare global {
-    var selectedQuestionsToRemove: string[] | undefined;
-}
+import { getPollObject } from "../../utils/poll-store";
+import { logMessageTimer } from "../../utils/timer";
 
 export async function questionRemove(interaction: StringSelectMenuInteraction) {
     try {
+
+        const poll = getPollObject(interaction.user.id);
+        if (!poll) {
+            await interaction.reply({
+                content: "Impossible de trouver le sondage. Veuillez réessayer.",
+                flags: MessageFlags.Ephemeral
+            });
+            setTimeout(async () => {
+                await interaction.deleteReply();
+            }, logMessageTimer);
+            return;
+        }
+
         // Récupérer les valeurs sélectionnées
-        const selectedValues = interaction.values;
-        
+        const selectedValues = interaction.values.map(value => parseInt(value.replace("question_", "")));
+
         // Stocker les questions sélectionnées dans la variable globale
-        global.selectedQuestionsToRemove = selectedValues;
-        
+        poll.selectedQuestions = selectedValues;
+        interaction.deferUpdate();
         console.log(`Questions sélectionnées pour la suppression: ${selectedValues.join(", ")}`);
-        
-        // Répondre à l'interaction
-        await interaction.update({
-            content: `${selectedValues.length} question(s) sélectionnée(s) pour la suppression. Cliquez sur "Confirmer la suppression" pour continuer ou "Annuler" pour annuler.`
-        });
+
     } catch (error) {
         console.error("Erreur lors de la sélection des questions à supprimer:", error);
-        await interaction.reply({ 
-            content: "Une erreur est survenue lors de la sélection des questions. Veuillez réessayer.", 
-            flags: MessageFlags.Ephemeral 
+        await interaction.reply({
+            content: "Une erreur est survenue lors de la sélection des questions. Veuillez réessayer.",
+            flags: MessageFlags.Ephemeral
         });
     }
 } 

--- a/src/handlers/select-menus/question-select.ts
+++ b/src/handlers/select-menus/question-select.ts
@@ -5,7 +5,7 @@ import { questionEmbed } from "../../utils/components";
 
 export async function questionSelect(interaction: StringSelectMenuInteraction) {
     try {
-        
+
         const poll = getPollObject(interaction.user.id);
         if (!poll) {
             await interaction.reply({
@@ -17,50 +17,50 @@ export async function questionSelect(interaction: StringSelectMenuInteraction) {
             }, logMessageTimer);
             return;
         }
-        
+
         const questions = poll.questions;
 
         // Récupérer l'index de la question sélectionnée
         const selectedValue = interaction.values[0];
         const questionIndex = parseInt(selectedValue.replace("question_", ""));
-        
+
         console.log(`Questions trouvées pour la sélection: ${questions.length}, index sélectionné: ${questionIndex}`);
-        
+
         // Vérifier que l'index est valide
         if (questionIndex < 0 || questionIndex >= questions.length) {
-            await interaction.reply({ 
-                content: "Erreur: Question introuvable", 
-                flags: MessageFlags.Ephemeral 
+            await interaction.reply({
+                content: "Erreur: Question introuvable",
+                flags: MessageFlags.Ephemeral
             });
             return;
         }
-        
+
         // Récupérer la question sélectionnée
         const selectedQuestion = questions[questionIndex];
-        
+
         console.log(`Question sélectionnée: ${selectedQuestion.content}`);
-        
+
         // Créer les boutons pour les actions sur la question
         const editQuestionButton = new ButtonBuilder()
             .setCustomId(`editQuestionText_${questionIndex}`)
             .setLabel("Modifier la question")
             .setStyle(ButtonStyle.Primary);
-        
+
         const addProposalButton = new ButtonBuilder()
             .setCustomId(`addProposal_${questionIndex}`)
             .setLabel("Ajouter une proposition")
             .setStyle(ButtonStyle.Primary);
-        
+
         const editProposalButton = new ButtonBuilder()
             .setCustomId(`editProposal_${questionIndex}`)
             .setLabel("Modifier une proposition")
             .setStyle(ButtonStyle.Primary);
-        
+
         const deleteProposalButton = new ButtonBuilder()
             .setCustomId(`deleteProposal_${questionIndex}`)
             .setLabel("Supprimer une proposition")
             .setStyle(ButtonStyle.Danger);
-        
+
         // Créer le menu pour le choix multiple
         const multipleChoiceMenu = new StringSelectMenuBuilder()
             .setCustomId('questionMultipleChoiceMenu')
@@ -70,35 +70,35 @@ export async function questionSelect(interaction: StringSelectMenuInteraction) {
                     .setLabel("Oui")
                     .setValue('questionMultipleChoiceMenuYes')
                     .setDescription("Permettre la sélection de plusieurs réponses")
-                    .setDefault(selectedQuestion.isMultipleAnswer===true),
+                    .setDefault(selectedQuestion.isMultipleAnswer === true),
                 new StringSelectMenuOptionBuilder()
                     .setLabel("Non")
                     .setValue('questionMultipleChoiceMenuNo')
                     .setDescription("Limiter à une seule réponse")
-                    .setDefault(selectedQuestion.isMultipleAnswer===false)
+                    .setDefault(selectedQuestion.isMultipleAnswer === false)
             );
-        
+
         // Créer les boutons pour enregistrer ou annuler
         const saveButton = new ButtonBuilder()
             .setCustomId(`saveQuestion_${questionIndex}`)
             .setLabel("Enregistrer la question")
             .setStyle(ButtonStyle.Success);
-        
+
         const cancelButton = new ButtonBuilder()
             .setCustomId("cancelEditQuestion")
             .setLabel("Annuler")
             .setStyle(ButtonStyle.Secondary);
-        
+
         // Créer les lignes pour les composants
         const actionRow1 = new ActionRowBuilder<ButtonBuilder>()
             .addComponents(editQuestionButton, addProposalButton, editProposalButton, deleteProposalButton);
-        
+
         const actionRow2 = new ActionRowBuilder<StringSelectMenuBuilder>()
             .addComponents(multipleChoiceMenu);
-        
+
         const actionRow3 = new ActionRowBuilder<ButtonBuilder>()
             .addComponents(saveButton, cancelButton);
-        
+
         // Mettre à jour le message avec les options de modification
         await interaction.update({
             content: `Modification de la question ${questionIndex + 1} : ${selectedQuestion.content}`,
@@ -107,9 +107,9 @@ export async function questionSelect(interaction: StringSelectMenuInteraction) {
         });
     } catch (error) {
         console.error("Erreur lors de la sélection de question:", error);
-        await interaction.reply({ 
-            content: "Une erreur est survenue lors de la sélection de la question. Veuillez réessayer.", 
-            flags: MessageFlags.Ephemeral 
+        await interaction.reply({
+            content: "Une erreur est survenue lors de la sélection de la question. Veuillez réessayer.",
+            flags: MessageFlags.Ephemeral
         });
     }
 } 

--- a/src/handlers/select-menus/question-select.ts
+++ b/src/handlers/select-menus/question-select.ts
@@ -1,28 +1,28 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, StringSelectMenuBuilder, StringSelectMenuInteraction, StringSelectMenuOptionBuilder, MessageFlags } from "discord.js";
+import { getPollObject } from "../../utils/poll-store";
+import { logMessageTimer } from "../../utils/timer";
+import { questionEmbed } from "../../utils/components";
 
 export async function questionSelect(interaction: StringSelectMenuInteraction) {
     try {
-        // Récupérer l'index de la question sélectionnée
-        const selectedValue = interaction.values[0];
-        const questionIndex = parseInt(selectedValue.replace("question_", ""));
         
-        // Récupérer le message original
-        const message = interaction.message;
-        if (!message) {
-            await interaction.reply({ 
-                content: "Erreur: Message introuvable", 
-                flags: MessageFlags.Ephemeral 
+        const poll = getPollObject(interaction.user.id);
+        if (!poll) {
+            await interaction.reply({
+                content: "Impossible de trouver le sondage. Veuillez réessayer.",
+                flags: MessageFlags.Ephemeral
             });
+            setTimeout(async () => {
+                await interaction.deleteReply();
+            }, logMessageTimer);
             return;
         }
         
-        // Récupérer l'embed existant
-        const embed = EmbedBuilder.from(message.embeds[0]);
-        const description = embed.data.description || "";
-        
-        // Extraire les questions du message
-        const sections = description.split("\n\n");
-        const questions = sections.filter(q => q.includes("**Question"));
+        const questions = poll.questions;
+
+        // Récupérer l'index de la question sélectionnée
+        const selectedValue = interaction.values[0];
+        const questionIndex = parseInt(selectedValue.replace("question_", ""));
         
         console.log(`Questions trouvées pour la sélection: ${questions.length}, index sélectionné: ${questionIndex}`);
         
@@ -37,9 +37,8 @@ export async function questionSelect(interaction: StringSelectMenuInteraction) {
         
         // Récupérer la question sélectionnée
         const selectedQuestion = questions[questionIndex];
-        const questionText = selectedQuestion.replace(/\*\*Question \d+:\*\*/, "").trim();
         
-        console.log(`Question sélectionnée: ${questionText}`);
+        console.log(`Question sélectionnée: ${selectedQuestion.content}`);
         
         // Créer les boutons pour les actions sur la question
         const editQuestionButton = new ButtonBuilder()
@@ -64,17 +63,19 @@ export async function questionSelect(interaction: StringSelectMenuInteraction) {
         
         // Créer le menu pour le choix multiple
         const multipleChoiceMenu = new StringSelectMenuBuilder()
-            .setCustomId(`multipleChoice_${questionIndex}`)
+            .setCustomId('questionMultipleChoiceMenu')
             .setPlaceholder("Choix multiple")
             .addOptions(
                 new StringSelectMenuOptionBuilder()
                     .setLabel("Oui")
-                    .setValue(`multipleChoice_yes_${questionIndex}`)
-                    .setDescription("Permettre la sélection de plusieurs réponses"),
+                    .setValue('questionMultipleChoiceMenuYes')
+                    .setDescription("Permettre la sélection de plusieurs réponses")
+                    .setDefault(selectedQuestion.isMultipleAnswer===true),
                 new StringSelectMenuOptionBuilder()
                     .setLabel("Non")
-                    .setValue(`multipleChoice_no_${questionIndex}`)
+                    .setValue('questionMultipleChoiceMenuNo')
                     .setDescription("Limiter à une seule réponse")
+                    .setDefault(selectedQuestion.isMultipleAnswer===false)
             );
         
         // Créer les boutons pour enregistrer ou annuler
@@ -100,8 +101,8 @@ export async function questionSelect(interaction: StringSelectMenuInteraction) {
         
         // Mettre à jour le message avec les options de modification
         await interaction.update({
-            content: `Modification de la question ${questionIndex + 1} : ${questionText}`,
-            embeds: [embed],
+            content: `Modification de la question ${questionIndex + 1} : ${selectedQuestion.content}`,
+            embeds: [questionEmbed(selectedQuestion)],
             components: [actionRow1, actionRow2, actionRow3]
         });
     } catch (error) {

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -5,7 +5,6 @@ export interface Poll {
 	uuidAuthor: string;
 	uuidMessage: string;
 	isAnonymous: boolean;
-	isClosed: boolean;
 	duration: number;
 	questions: Question[];
 	selectedQuestions: number[];

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -1,10 +1,12 @@
 import { Question } from './question';
 
 export interface Poll {
-  title: string;
-  uuidMessage: string;
-  isAnonymous: boolean;
-  isClosed: boolean;
-  duration: number;
-  questions: Question[];
+	title: string;
+	uuidAuthor: string;
+	uuidMessage: string;
+	isAnonymous: boolean;
+	isClosed: boolean;
+	duration: number;
+	questions: Question[];
+	selectedQuestions: number[];
 } 

--- a/src/utils/components.ts
+++ b/src/utils/components.ts
@@ -1,10 +1,21 @@
-import { ButtonBuilder, ButtonStyle, ActionRowBuilder, EmbedBuilder } from "discord.js";
+import { ButtonBuilder, ButtonStyle, ActionRowBuilder, EmbedBuilder, StringSelectMenuBuilder } from "discord.js";
 import { Poll } from "../models/poll";
 import { Question } from "../models/question";
+
+function durationToString(duration: number): string {
+	if (duration < 1) return `${duration * 60} minutes`;
+	else if (duration > 24) return `${duration / 24} ${duration / 24} jours`;
+	else return `${duration} ${duration === 1 ? "heure" : "heures"}`;
+}
 
 export function pollEmbed(poll: Poll): EmbedBuilder {
 	const embed = new EmbedBuilder()
 		.setTitle(`Titre : ${poll.title}`)
+		.setDescription(
+			`**Auteur** : <@${poll.uuidAuthor}>` +
+			`\n**Anonyme** : ${poll.isAnonymous ? "Oui" : "Non"}` +
+			`\n**Durée** : ${durationToString(poll.duration)}`
+		)
 		.setFooter({
 			text: "Utilisez les boutons ci-dessous pour gérer les questions du sondage"
 		});
@@ -53,12 +64,11 @@ export function initRow(): ActionRowBuilder<ButtonBuilder> {
 	return new ActionRowBuilder<ButtonBuilder>().addComponents(createPollButton, createPollTemplateButton, editPollTemplateButton);;
 }
 
-export function pollRow1(): ActionRowBuilder<ButtonBuilder> {
-	const editTitleButton = new ButtonBuilder()
-		.setCustomId("feedbackEditTitleButton")
-		.setLabel("Modifier le titre du questionnaire")
-		.setStyle(ButtonStyle.Primary);
+export function pollRows(): ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] {
+	return [pollRow1(), pollRow2()];
+}
 
+export function pollRow1(): ActionRowBuilder<ButtonBuilder> {
 	const addQuestionButton = new ButtonBuilder()
 		.setCustomId("feedbackQuestionAddButton")
 		.setLabel("Ajouter une question")
@@ -74,5 +84,43 @@ export function pollRow1(): ActionRowBuilder<ButtonBuilder> {
 		.setLabel("Supprimer une ou plusieurs questions")
 		.setStyle(ButtonStyle.Primary);
 
-	return new ActionRowBuilder<ButtonBuilder>().addComponents(editTitleButton, addQuestionButton, editQuestionButton, removeQuestionButton);
+	return new ActionRowBuilder<ButtonBuilder>().addComponents(addQuestionButton, editQuestionButton, removeQuestionButton);
+}
+
+export function pollRow2(): ActionRowBuilder<ButtonBuilder> {
+	// const isAnonymousMenu = new StringSelectMenuBuilder()
+	// 	.setCustomId("feedbackAnonymousMenu")
+	// 	.setPlaceholder("Anonyme ?")
+	// 	.addOptions([
+	// 		{ label: "Oui", value: "true" },
+	// 		{ label: "Non", value: "false" }
+	// 	]);
+
+	// const durationMenu = new StringSelectMenuBuilder()
+	// 	.setCustomId("feedbackDurationMenu")
+	// 	.setPlaceholder("Durée")
+	// 	.addOptions([
+	// 		{ label: "1 heure", value: "1" },
+	// 		{ label: "2 heures", value: "2" },
+	// 		{ label: "4 heures", value: "4" },
+	// 		{ label: "8 heures", value: "8" },
+	// 		{ label: "24 heures", value: "24" },
+	// 	]);
+	
+	const editTitleButton = new ButtonBuilder()
+		.setCustomId("feedbackEditTitleButton")
+		.setLabel("Modifier le titre du questionnaire")
+		.setStyle(ButtonStyle.Primary);
+
+	const isAnonymousButton = new ButtonBuilder()
+		.setCustomId("feedbackAnonymousButton")
+		.setLabel("Changer l'anonymat")
+		.setStyle(ButtonStyle.Primary);
+
+	const durationButton = new ButtonBuilder()
+		.setCustomId("feedbackDurationButton")
+		.setLabel("Changer la durée")
+		.setStyle(ButtonStyle.Primary);
+
+	return new ActionRowBuilder<ButtonBuilder>().addComponents(editTitleButton, isAnonymousButton, durationButton);
 }

--- a/src/utils/components.ts
+++ b/src/utils/components.ts
@@ -1,4 +1,39 @@
-import { ButtonBuilder, ButtonStyle, ActionRowBuilder } from "discord.js";
+import { ButtonBuilder, ButtonStyle, ActionRowBuilder, EmbedBuilder } from "discord.js";
+import { Poll } from "../models/poll";
+import { Question } from "../models/question";
+
+export function pollEmbed(poll: Poll): EmbedBuilder {
+	const embed = new EmbedBuilder()
+		.setTitle(`Titre : ${poll.title}`)
+		.setFooter({
+			text: "Utilisez les boutons ci-dessous pour gérer les questions du sondage"
+		});
+	if (poll.questions.length === 0) {
+		embed.addFields({ name: "⚠️ Aucune question ajoutée", value: "Ajoutez-en avec le bouton ci-dessous !" });
+	} else {
+		poll.questions.forEach((question, index) => {
+			embed.addFields({ name: `Question ${index + 1}`, value: question.content, inline: false });
+		});
+	}
+	return embed;
+}
+
+export function questionEmbed(question: Question): EmbedBuilder {
+	const embed = new EmbedBuilder()
+		.setTitle(`Question : ${question.content}`)
+		.setFooter({
+			text: "Utilisez les boutons ci-dessous pour gérer les propositions de la question"
+		});
+	if (question.answers.length === 0) {
+		embed.addFields({ name: "⚠️ Aucune proposition ajoutée", value: "Ajoutez-en avec le bouton ci-dessous !" });
+	} else {
+		question.answers.forEach((answer, index) => {
+			embed.addFields({ name: `Proposition ${index + 1}`, value: answer.content, inline: false });
+		});
+	}
+	return embed;
+
+}
 
 export function initRow(): ActionRowBuilder<ButtonBuilder> {
 	const createPollButton = new ButtonBuilder()
@@ -19,6 +54,11 @@ export function initRow(): ActionRowBuilder<ButtonBuilder> {
 }
 
 export function pollRow1(): ActionRowBuilder<ButtonBuilder> {
+	const editTitleButton = new ButtonBuilder()
+		.setCustomId("feedbackEditTitleButton")
+		.setLabel("Modifier le titre du questionnaire")
+		.setStyle(ButtonStyle.Primary);
+
 	const addQuestionButton = new ButtonBuilder()
 		.setCustomId("feedbackQuestionAddButton")
 		.setLabel("Ajouter une question")
@@ -33,5 +73,6 @@ export function pollRow1(): ActionRowBuilder<ButtonBuilder> {
 		.setCustomId("feedbackQuestionRemoveButton")
 		.setLabel("Supprimer une ou plusieurs questions")
 		.setStyle(ButtonStyle.Primary);
-	return new ActionRowBuilder<ButtonBuilder>().addComponents(addQuestionButton, editQuestionButton, removeQuestionButton);
+
+	return new ActionRowBuilder<ButtonBuilder>().addComponents(editTitleButton, addQuestionButton, editQuestionButton, removeQuestionButton);
 }

--- a/src/utils/poll-store.ts
+++ b/src/utils/poll-store.ts
@@ -8,8 +8,7 @@ export function createPollObject(userId: string, title: string): Poll {
         uuidMessage: "",
         uuidAuthor: userId,
         isAnonymous: false,
-        isClosed: false,
-        duration: 0,
+        duration: 1,
         questions: [],
         selectedQuestions: []
     };

--- a/src/utils/poll-store.ts
+++ b/src/utils/poll-store.ts
@@ -1,0 +1,43 @@
+import { Poll } from "../models/poll";
+
+const pollMap = new Map<string, Poll>();
+
+export function createPollObject(userId: string, title: string): Poll {
+    const poll: Poll = {
+        title: title,
+        uuidMessage: "",
+        uuidAuthor: userId,
+        isAnonymous: false,
+        isClosed: false,
+        duration: 0,
+        questions: [],
+        selectedQuestions: []
+    };
+
+    pollMap.set(userId, poll);
+    return poll;
+}
+
+export function getPollObject(userId: string): Poll | undefined {
+    return pollMap.get(userId);
+}
+
+export function deletePollObject(userId: string): void {
+    pollMap.delete(userId);
+}
+
+export function addPollQuestion(poll: Poll, question: string) {
+    poll.questions.push({
+        content: question,
+        isMultipleAnswer: false,
+        answers: []
+    });
+}
+
+export function removePollQuestion(poll: Poll) {
+    poll.selectedQuestions.sort((a, b) => b - a);
+    poll.selectedQuestions.forEach(index => {
+        poll.questions.splice(index, 1);
+    });
+    poll.selectedQuestions = [];
+}


### PR DESCRIPTION
- Ajout du `poll-store` dans `src/utils/poll-store.ts,` permettant de gérer le questionnaire en cours de création pour chaque utilisateurs
- Ajout de la logique permettant la création du questionnaire dans les différentes intéractions (en utilisant l'interface `Poll` que nous avons créer)
- Ajout de la fonction de modification du titre du questionnaire
- Simplification de la création des `Embed`, la création se fait désormais avec une simple fonction dans `src/utils/components.ts`
- Simplification de la création des `ActionRow` avec une fonction, pour les utiliser plus rapidement
- Ajout d'un bouton pour changer l'anonymat du questionnaire